### PR TITLE
Feature/use paragonie hidden string and composer php73

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^7.3",
     "ext-sodium": "*",
     "doctrine/annotations": "^1.6",
     "doctrine/orm": "^2.6",
     "paragonie/halite": "^4.4",
+    "paragonie/hidden-string": "^1.0",
     "zendframework/zend-modulemanager": "^2.8",
     "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
     "zendframework/zend-stdlib": "^3.2"

--- a/src/Adapter/EncryptionAdapter.php
+++ b/src/Adapter/EncryptionAdapter.php
@@ -5,9 +5,9 @@ namespace Keet\Encrypt\Adapter;
 use Keet\Encrypt\Interfaces\EncryptionInterface;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
 use ParagonIE\Halite\Symmetric\Crypto;
 use ParagonIE\Halite\Symmetric\EncryptionKey;
+use ParagonIE\HiddenString\HiddenString;
 
 class EncryptionAdapter implements EncryptionInterface
 {

--- a/src/Adapter/HashingAdapter.php
+++ b/src/Adapter/HashingAdapter.php
@@ -5,9 +5,9 @@ namespace Keet\Encrypt\Adapter;
 use Keet\Encrypt\Interfaces\HashingInterface;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
 use ParagonIE\Halite\Password;
 use ParagonIE\Halite\Symmetric\EncryptionKey;
+use ParagonIE\HiddenString\HiddenString;
 use TypeError;
 
 class HashingAdapter implements HashingInterface


### PR DESCRIPTION
* Paragonie Halite has split off the HiddenString class into a separate module. The class alias in its stead has been commented (in commit) as being deprecated and to be removed in version 5. This change created version [4.5.1](https://github.com/paragonie/halite/releases/tag/v4.5.1)
* Added PHP 7.3 as an alternative to PHP 7.2 in platform requirements
